### PR TITLE
Set HTML process variable as object instead of string.

### DIFF
--- a/berkelybridge-textgenerator/backend/gradle.properties
+++ b/berkelybridge-textgenerator/backend/gradle.properties
@@ -5,4 +5,4 @@ valtimoVersion=12.5.0.2.RC-SNAPSHOT
 
 pluginGroupId=com.ritense.valtimo
 pluginArtifactId=berkelybridge-textgenerator
-pluginVersion=1.2.2
+pluginVersion=1.2.3

--- a/berkelybridge-textgenerator/backend/plugin/src/main/kotlin/com/ritense/valtimo/berkelybridge/plugin/BerkelyBridgePlugin.kt
+++ b/berkelybridge-textgenerator/backend/plugin/src/main/kotlin/com/ritense/valtimo/berkelybridge/plugin/BerkelyBridgePlugin.kt
@@ -34,6 +34,8 @@ import com.ritense.valueresolver.ValueResolverService
 import java.net.URL
 import mu.KotlinLogging
 import org.camunda.bpm.engine.delegate.DelegateExecution
+import org.camunda.bpm.engine.variable.Variables
+import org.camunda.bpm.engine.variable.value.SerializationDataFormat
 import org.springframework.context.ApplicationEventPublisher
 
 private val logger = KotlinLogging.logger {}
@@ -73,7 +75,12 @@ class BerkelyBridgePlugin(
             naam = naam,
             format = format)
 
-            execution.setVariable(variabeleNaam, text);
+            execution.setVariable(
+                variabeleNaam,
+                Variables.objectValue(text).serializationDataFormat(
+                    Variables.SerializationDataFormats.JAVA
+                ).create()
+            )
     }
 
     @PluginAction(


### PR DESCRIPTION
When setting the generated HTML as a process variable, we now set it as an object instead of a string, so we are not limited to the 4000 character database column limit. (The way it will be stored in the database is different, but it will still be retrieved as a String.)