### PR TITLE
Updated the EmailApiPlugin so that it now supports multiple recipients in the to/cc/bcc fields.

### DIFF
--- a/backend/amsterdam-email-api/src/main/kotlin/com/ritense/valtimoplugins/amsterdam/emailapi/plugin/EmailAddress.kt
+++ b/backend/amsterdam-email-api/src/main/kotlin/com/ritense/valtimoplugins/amsterdam/emailapi/plugin/EmailAddress.kt
@@ -1,0 +1,5 @@
+package com.ritense.valtimoplugins.amsterdam.emailapi.plugin
+
+import java.io.Serializable
+
+data class EmailAddress(val address: String, val name: String? = null) : Serializable


### PR DESCRIPTION
This change is backwards compatible, so passing only the old `toEmail`/`toName` properties will still work.